### PR TITLE
circleci: use main branch instead of master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,4 +39,4 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only: main


### PR DESCRIPTION
This PR was created by robots